### PR TITLE
Sprint 3 : feat: display profile in form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-menubar": "^1.0.4",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-switch": "^1.0.3",
         "@radix-ui/react-tabs": "^1.0.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
@@ -2230,6 +2231,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.0.3.tgz",
+      "integrity": "sha512-mxm87F88HyHztsI7N+ZUmEoARGkC22YVW5CaC+Byc+HRpuvCrOBPTAnXgf+tZ/7i0Sg/eOePGdMhUKhPaQEqow==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-use-size": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-menubar": "^1.0.4",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-switch": "^1.0.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "firebase": "^10.7.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 /** ROOTER */
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import Layout from './components/layout/Layout';
 /** PAGES */
 
@@ -12,6 +12,7 @@ import NewArticle from './pages/NewArticle';
 import Search from './pages/Search';
 import User from './pages/User';
 import Authentification from './pages/Authentification';
+import Settings from './pages/Settings';
 
 function App() {
   return (
@@ -31,6 +32,12 @@ function App() {
           <Route path="/search" element={<Search />} />
           {/* Page de recherche par categorie via navbar */}
           <Route path="/catalog/" element={<Catalog />} />
+          {/* Page de settings du profil */}
+          <Route path="/settings/:section" element={<Settings />} />
+          <Route
+            path="/settings"
+            element={<Navigate to="/settings/profile" />}
+          />
           <Route path="/*" element={<Error404 />} />
         </Route>
       </Routes>

--- a/src/components/form-modify-profile/FormDescription.tsx
+++ b/src/components/form-modify-profile/FormDescription.tsx
@@ -1,0 +1,28 @@
+import { UserDocument } from '@/types/types';
+import { UseFormRegister } from 'react-hook-form';
+
+type FormDescriptionProps = {
+  register: UseFormRegister<UserDocument>;
+  description: string | null | undefined;
+};
+
+const FormDescription = ({ register, description }: FormDescriptionProps) => {
+  return (
+    <div className="flex flex-wrap p-6">
+      <div className="w-full md:w-1/2">
+        <label htmlFor="description">À propos de toi</label>
+      </div>
+      <div className="w-full md:w-1/2">
+        <textarea
+          {...register('description', { required: false })}
+          className="h-28 w-full border-b focus-visible:border-b focus-visible:border-vintedGreen focus-visible:outline-none"
+          placeholder="ex: ingénieur, joueur de foot"
+          id="description"
+          value={description ?? ''}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FormDescription;

--- a/src/components/form-modify-profile/FormDisplayCityInProfile.tsx
+++ b/src/components/form-modify-profile/FormDisplayCityInProfile.tsx
@@ -1,0 +1,34 @@
+import { UserDocument } from '@/types/types';
+import { UseFormRegister } from 'react-hook-form';
+
+import Switch from '../ui/switch';
+
+type FormDisplayCityInProfileProps = {
+  register: UseFormRegister<UserDocument>;
+  displayCityInProfile: boolean | undefined;
+};
+
+const FormDisplayCityInProfile = ({
+  register,
+  displayCityInProfile,
+}: FormDisplayCityInProfileProps) => {
+  return (
+    <div className="flex flex-wrap justify-between p-6">
+      <div className="w-full md:w-1/2">
+        <label htmlFor="displayCityInProfile">
+          Afficher la ville dans le profil
+        </label>
+      </div>
+      <div className="w-full md:w-1/2">
+        <Switch
+          {...register('displayCityInProfile', { required: true })}
+          id="displayCityInProfile"
+          checked={displayCityInProfile}
+          className="bg-vintedGreen"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default FormDisplayCityInProfile;

--- a/src/components/form-modify-profile/FormModifyProfile.tsx
+++ b/src/components/form-modify-profile/FormModifyProfile.tsx
@@ -1,0 +1,93 @@
+import { UserDocument } from '@/types/types';
+import { useForm } from 'react-hook-form';
+import useFirebaseAuth from '@/hooks/useFirebaseAuth';
+import languages from '@/data/languages';
+import FormDescription from './FormDescription';
+import FormSelect from './FormSelect';
+import FormDisplayCityInProfile from './FormDisplayCityInProfile';
+import FormProfileInput from './FormProfileInput';
+import FormModifyProfilePicture from './FormModifyProfilePicture';
+
+const FormModifyProfile = () => {
+  const { authUser } = useFirebaseAuth();
+  const userDocument = authUser?.userDocument;
+  const {
+    handleSubmit,
+    register,
+    formState: { errors },
+  } = useForm<UserDocument>();
+
+  const onSubmit = (data: UserDocument) => {
+    console.log('🚀 ~ onSubmit ~ data:', data);
+    //TODO: to implement to update profile
+  };
+
+  return (
+    <div className="container mx-auto flex max-w-[960px] flex-col items-center px-2">
+      <div className="w-full py-4">
+        <h1 className="text-left text-2xl">Détails du profil</h1>
+      </div>
+      {/* FORMULAIRE */}
+      {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
+      <form className="w-full" onSubmit={handleSubmit(onSubmit)}>
+        <div className="mt-6 bg-vintedBackground">
+          <FormModifyProfilePicture
+            photoURL={userDocument?.photoURL}
+            login={userDocument?.login}
+          />
+          <hr />
+          <FormDescription
+            register={register}
+            description={userDocument?.description}
+          />
+        </div>
+
+        <div className="mt-6 bg-vintedBackground">
+          <FormProfileInput
+            register={register}
+            errors={errors}
+            errorMsg="Entrez un pays"
+            id="country"
+            label="Pays"
+            value={userDocument?.country}
+          />
+          <hr />
+          <FormProfileInput
+            register={register}
+            errors={errors}
+            errorMsg="Entrez une ville"
+            id="city"
+            label="Ville"
+            value={userDocument?.city}
+          />
+          <hr />
+          <FormDisplayCityInProfile
+            register={register}
+            displayCityInProfile={userDocument?.displayCityInProfile}
+          />
+        </div>
+
+        <div className="mt-6 bg-vintedBackground">
+          <FormSelect
+            register={register}
+            value={userDocument?.language}
+            choices={languages}
+            id="language"
+            label="Langue"
+            hasPlaceHolder={false}
+          />
+        </div>
+        <div className="mb-8 mt-11 flex justify-end">
+          <button
+            type="submit"
+            className="h-[42px] rounded bg-vintedGreen px-[14px] text-center text-vintedBackground"
+          >
+            Mettre à jour
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default FormModifyProfile;

--- a/src/components/form-modify-profile/FormModifyProfilePicture.tsx
+++ b/src/components/form-modify-profile/FormModifyProfilePicture.tsx
@@ -1,0 +1,36 @@
+type FormModifyProfilePictureProps = {
+  photoURL?: string;
+  login?: string;
+};
+
+const FormModifyProfilePicture = ({
+  photoURL,
+  login,
+}: FormModifyProfilePictureProps) => {
+  return (
+    <div className="flex p-6">
+      <div className="w-full md:w-1/2">
+        <span>Ta photo de profil</span>
+      </div>
+      <div className="flex w-full justify-end gap-6 md:w-1/2">
+        {photoURL === '' ? (
+          <img
+            src="../../avatar.png"
+            alt="avatar"
+            className="h-16 w-16 rounded-full"
+          />
+        ) : (
+          <img src={photoURL} alt={login} className="h-16 w-16 rounded-full" />
+        )}
+        <button
+          className="flex h-[42px] cursor-not-allowed items-center rounded border border-vintedGreen px-[14px] text-vintedGreen"
+          disabled
+        >
+          Choisir une photo
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FormModifyProfilePicture;

--- a/src/components/form-modify-profile/FormProfileInput.tsx
+++ b/src/components/form-modify-profile/FormProfileInput.tsx
@@ -1,0 +1,43 @@
+import { UserDocument } from '@/types/types';
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
+
+type FormProfileInputProps = {
+  register: UseFormRegister<UserDocument>;
+  errors: FieldErrors<UserDocument>;
+  errorMsg: string;
+  id: 'country' | 'city';
+  label: 'Pays' | 'Ville';
+  value?: string;
+};
+
+const FormProfileInput = ({
+  register,
+  errors,
+  errorMsg,
+  id,
+  label,
+  value,
+}: FormProfileInputProps) => {
+  return (
+    <div className="flex flex-wrap border-b p-6">
+      <div className="w-full md:w-1/2">
+        <label htmlFor={id}>{label}</label>
+      </div>
+      <div className="w-full md:w-1/2">
+        <input
+          type="text"
+          {...register(id, { required: true })}
+          className="w-full border-b pb-1 focus-visible:border-b focus-visible:border-vintedGreen focus-visible:outline-none"
+          placeholder="ex: Chemise sésame verte"
+          id={id}
+          value={value}
+        />
+        {errors[id] && (
+          <span className="text-sm text-vintedGreen">{errorMsg}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FormProfileInput;

--- a/src/components/form-modify-profile/FormSelect.tsx
+++ b/src/components/form-modify-profile/FormSelect.tsx
@@ -1,0 +1,53 @@
+import { UserDocument } from '@/types/types';
+import { UseFormRegister } from 'react-hook-form';
+
+type FormSelectProps = {
+  register: UseFormRegister<UserDocument>;
+  value: string | undefined;
+  choices: string[];
+  id: 'country' | 'city' | 'language';
+  label: 'Pays' | 'Ville' | 'Langue';
+  hasPlaceHolder: boolean;
+  placeHolder?: string;
+};
+
+const FormSelect = ({
+  register,
+  value,
+  choices,
+  id,
+  label,
+  hasPlaceHolder,
+  placeHolder,
+}: FormSelectProps) => {
+  return (
+    <div className="flex flex-wrap p-6">
+      <div className="w-full md:w-1/2">
+        <label htmlFor={id}>{label}</label>
+      </div>
+      <div className="w-full md:w-1/2">
+        <select
+          {...register(id, { required: true })}
+          className="w-full border-b text-vintedTextGrisFonce focus-visible:border-b focus-visible:border-vintedGreen focus-visible:outline-none"
+          id={id}
+          value={value}
+        >
+          {hasPlaceHolder && (
+            <option hidden defaultValue="">
+              {placeHolder}
+            </option>
+          )}
+          {choices.map((choice) => {
+            return (
+              <option key={choice} value={choice}>
+                {choice}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default FormSelect;

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,28 @@
+// Generated with shadcn
+import * as React from 'react';
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+
+import { cn } from '@/lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0',
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export default Switch;

--- a/src/data/languages.ts
+++ b/src/data/languages.ts
@@ -1,0 +1,3 @@
+const languages = ['français', 'anglais', 'espagnol', 'neerlandais'];
+
+export default languages;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,25 @@
+import useFirebaseAuth from '@/hooks/useFirebaseAuth';
+import ModalAuth from '@/components/modals/authentification/ModalAuth';
+import FormModifyProfile from '@/components/form-modify-profile/FormModifyProfile';
+import { useParams } from 'react-router-dom';
+
+const PROFILE_SECTION = 'profile';
+
+const Settings = () => {
+  const { section } = useParams();
+  const { authUser } = useFirebaseAuth();
+  let eltToDisplay;
+  if (!authUser) {
+    eltToDisplay = <ModalAuth setModalConnexion={() => {}} />;
+  } else if (section === PROFILE_SECTION) {
+    eltToDisplay = <FormModifyProfile />;
+  } else {
+    throw Error(`Unknown route /settings/${section}`);
+  }
+
+  return (
+    <section className="bg-vintedBackgroundCard pt-5">{eltToDisplay}</section>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
Feature : afficher les infos du profil dans un formulaire.

- Comme discuté en meeting, la mise à jour des infos du profil n'a pas été implémenté. Ce serait fait dans un second temps
- Le select "Langue" est différent du site officiel mais c'est pas très grave vu que ça fait le job
- Les scénarios que ça couvre : 
   - Si le user est déconnecté et va sur http://localhost:5173/settings/profile, l'authentification est demandée
   - http://localhost:5173/settings est redirigé automatiquement sur http://localhost:5173/settings/profile
   - Une erreur est levée si le paramètre section dans http://localhost:5173/settings/:section n'est pas "profile"

Pour rappel pour tester:
 Email : test@test.fr et mdp : 7654321

Pour se déconnecter sans le bouton déconnexion : vider le cache du site ("Cookies and site data" => "Manage on-device site data" => supprimer la ligne localhost)

<img width="260" alt="image" src="https://github.com/arnaudpant/vinted/assets/10980068/fab34ea8-13d4-44e8-8e24-f96093cc3b1f">
